### PR TITLE
Add clickable label to checkboxes

### DIFF
--- a/player/index.html
+++ b/player/index.html
@@ -54,12 +54,12 @@ Licensed under the MIT License (view LICENSE.md for more information)
                 <li id="restart">Restart</li>
                 <li>Settings
                     <ul>
-                        <li><input type="checkbox" id="skip_boot"> Skip Boot Intro</li>
-                        <li><input type="checkbox" id="toggleSmoothScaling" checked="checked"> Smooth Scaling</li>
-                        <li><input type="checkbox" id="toggleDynamicSpeed"> Dynamic Speed</li>
-                        <li><input type="checkbox" id="offthread-cpu" checked="checked"> CPU off-thread</li>
-                        <li><input type="checkbox" id="offthread-gpu" checked="checked"> GPU off-thread</li>
-                        <li><input type="checkbox" id="sound"> Sound</li>
+                        <li><label><input type="checkbox" id="skip_boot"> Skip Boot Intro</label></li>
+                        <li><label><input type="checkbox" id="toggleSmoothScaling" checked="checked"> Smooth Scaling</label></li>
+                        <li><label><input type="checkbox" id="toggleDynamicSpeed"> Dynamic Speed</label></li>
+                        <li><label><input type="checkbox" id="offthread-cpu" checked="checked"> CPU off-thread</label></li>
+                        <li><label><input type="checkbox" id="offthread-gpu" checked="checked"> GPU off-thread</label></li>
+                        <li><label><input type="checkbox" id="sound"> Sound</label></li>
                         <li>GBA Bindings
                             <ul>
                                 <li id="key_a"><span>A</span></li>


### PR DESCRIPTION
I noticed the labels for the checkbox settings were not clickable. This simply adds a `label` element around checkboxes so you can click the checkbox as well as the label text to toggle the setting.