### PR TITLE
Fix emulator freeze after iOS auto screen lock

### DIFF
--- a/modules/XAudioJS/XAudioServer.js
+++ b/modules/XAudioJS/XAudioServer.js
@@ -226,20 +226,19 @@ XAudioServer.prototype.setupWebAudio = function () {
     XAudioJSWebAudioAudioNode.connect(XAudioJSWebAudioContextHandle.destination);																//Send and chain the output of the audio manipulation to the system audio output.
 	this.resetCallbackAPIAudioBuffer(XAudioJSWebAudioContextHandle.sampleRate);
 	/*
-     Firefox has a bug in its web audio implementation...
-     The node may randomly stop playing on Mac OS X for no
-     good reason. Keep a watchdog timer to restart the failed
-     node if it glitches. Google Chrome never had this issue.
+     The script processor node can stop firing for no good reason on some
+     platforms: historically on Firefox/Mac OS X, and on iOS Safari after
+     an auto screen-lock interruption (the AudioContext state stays "running"
+     but onaudioprocess never gets called again). Keep a watchdog timer to
+     restart the failed node if it glitches. Also resume the context when
+     it goes to "suspended" / "interrupted" (iOS uses the latter).
      */
     XAudioJSWebAudioWatchDogLast = (new Date()).getTime();
-    if (!XAudioJSWebAudioWatchDogTimer && navigator.userAgent.indexOf('Gecko/') > -1) {
-        if (XAudioJSWebAudioWatchDogTimer) {
-            clearInterval(XAudioJSWebAudioWatchDogTimer);
-        }
+    if (!XAudioJSWebAudioWatchDogTimer) {
         var parentObj = this;
         XAudioJSWebAudioWatchDogTimer = setInterval(function () {
 			if(typeof XAudioJSWebAudioContextHandle.state != "undefined") {
-				if (XAudioJSWebAudioContextHandle.state === 'suspended') {
+				if (XAudioJSWebAudioContextHandle.state === 'suspended' || XAudioJSWebAudioContextHandle.state === 'interrupted') {
 					XAudioJSWebAudioWatchDogLast = (new Date()).getTime();
 					try {
 						XAudioJSWebAudioContextHandle.resume();


### PR DESCRIPTION
## Summary

On iOS Safari, an auto screen lock leaves the `AudioContext` reporting `state === 'running'` while the `ScriptProcessor` callback permanently stops firing. The audio buffer stays full, `audioUnderrunAdjustment()` throttles `CPUCyclesTotal` down to 0, and the emulator looks frozen on resume.

The existing `setupWebAudio` watchdog (originally for the Firefox/macOS scriptnode bug) already has the right recovery: `XAudioJSWebAudioWatchDogLast` is updated **from inside the audio callback**, so `timeDiff > 500ms` is a generic \"node is dead\" signal — it was just gated to Gecko. Two changes in `modules/XAudioJS/XAudioServer.js`:

- Drop the `navigator.userAgent.indexOf('Gecko/')` gate so the watchdog runs everywhere.
- Treat iOS's `state === 'interrupted'` the same as `'suspended'` for context resume.

Net: **+8 / −9 lines, single file**.

iOS requires a user gesture to actually re-activate audio, so the user still has to tap once after unlock — but that single tap then reliably unsticks playback.

## Test plan

- [x] iPhone Safari: 30s and 2min auto lock → unlock → tap → audio + emulation resume.
- [x] macOS Firefox / Chrome / Safari: long playback regression check (no spurious re-init).